### PR TITLE
fixed protected EnableMouseWheel-call

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -474,7 +474,7 @@ function DialogKey:DisableQuestScrolling()		-- Frees up mouse wheel input again 
 		end
 	end
 	
-	if not found then
+	if not found and not UnitAffectingCombat("player") then
 		UIParent:EnableMouseWheel(false)
 	end
 end


### PR DESCRIPTION
it is not allowed to call EnableMouseWheel during combat and results in this error:
AddOn 'DialogKey' tried to call the protected function 'UIParent:EnableMouseWheel()'.

I found the fix here and it works for me: https://www.curseforge.com/wow/addons/dialogkey/issues/11