### PR TITLE
Update DialogKey.toc version

### DIFF
--- a/DialogKey.toc
+++ b/DialogKey.toc
@@ -2,7 +2,7 @@
 ## Title: DialogKey
 ## Notes: Lets you hit a key to confirm loot/purchase dialogs, accept/complete quests, select quest rewards, etc. Hit 2 to select a reward then spacebar to complete quests? Easy!
 ## Author: Foxthorn
-## Version: 1.8
+## Version: 1.8.6
 ## SavedVariables: DialogKeyDB
 ## OptionalDeps: Ace3
 ## X-Embeds: Ace3


### PR DESCRIPTION
Bumped the version so Addon managers that use the internal version of the addon won't complain the addon is outdated even though it isn't.